### PR TITLE
feat(splash-screen): enable body scroll after splash screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         content="Projet de splash screen animé en HTML, CSS et JavaScript avec transition fluide vers un contenu web stylisé.">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="stylesheet" href="./css/main.css">
+    <script src="./scripts/disable-scroll-after-splash.js" defer></script>
 </head>
 
 <body>

--- a/scripts/disable-scroll-after-splash.js
+++ b/scripts/disable-scroll-after-splash.js
@@ -1,0 +1,8 @@
+window.addEventListener("load", () => {
+  const splash = document.querySelector(".splash-screen");
+
+  setTimeout(() => {
+    splash.style.display = "none"; // ou opacity 0 si déjà géré par CSS
+    document.body.style.overflow = "auto"; // Réactive le scroll
+  }, 5000); // durée = délai animation (4s) + durée fadeOut (1s)
+});


### PR DESCRIPTION
- Created `disable-scroll-after-splash.js` to programmatically restore body scrolling once the splash screen is hidden.
- Removed the unused `.gitkeep` file from the scripts directory.
- Linked the new script in `index.html` to ensure proper execution on page load.

This change improves user experience by preventing scrolling during the splash screen display and restoring it once the main content is ready.